### PR TITLE
simplify API more

### DIFF
--- a/packages/react-core/src/components/Menu/Menu.tsx
+++ b/packages/react-core/src/components/Menu/Menu.tsx
@@ -16,7 +16,7 @@ export interface MenuProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'r
   /** Single itemId for single select menus, or array of itemIds for multi select. You can also specify isSelected on the MenuItem. */
   selected?: any | any[];
   /** Callback called when an MenuItems's action button is clicked. You can also specify it within a MenuItemAction. */
-  onActionClick?: (event?: any, itemId?: any) => void;
+  onActionClick?: (event?: any, itemId?: any, actionId?: any) => void;
   /** Search input of menu */
   hasSearchInput?: boolean;
   /** A callback for when the input value changes. */

--- a/packages/react-core/src/components/Menu/Menu.tsx
+++ b/packages/react-core/src/components/Menu/Menu.tsx
@@ -11,10 +11,14 @@ export interface MenuProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'r
   children?: React.ReactNode;
   /** Additional classes added to the Menu */
   className?: string;
-  /** Callback for updating when item selection changes */
+  /** Callback for updating when item selection changes. You can also specify onClick on the MenuItem. */
   onSelect?: (event?: any, itemId?: any) => void;
-  /** Callback called when an MenuItems's action button is clicked */
+  /** Single itemId for single select menus, or array of itemIds for multi select. You can also specify isSelected on the MenuItem. */
+  selected?: any | any[];
+  /** Callback called when an MenuItems's action button is clicked. You can also specify it within a MenuItemAction. */
   onActionClick?: (event?: any, itemId?: any) => void;
+  /** Search input of menu */
+  hasSearchInput?: boolean;
   /** A callback for when the input value changes. */
   onSearchInputChange?: (
     event: React.FormEvent<HTMLInputElement> | React.SyntheticEvent<HTMLButtonElement>,
@@ -22,10 +26,10 @@ export interface MenuProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'r
   ) => void;
   /** Accessibility label */
   'aria-label'?: string;
-  /** Indicates if menu is the flyout variant */
-  isFlyoutMenu?: boolean;
-  /** Search input of menu */
-  hasSearchInput?: boolean;
+  /** Indicates if menu contains a flyout menu */
+  containsFlyout?: boolean;
+  /** itemId of the currently active item. You can also specify isActive on the MenuItem. */
+  activeItemId?: any;
   /** Forwarded ref */
   innerRef?: React.Ref<any>;
 }
@@ -51,21 +55,23 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
       children,
       className,
       onSelect,
+      selected = null,
       onActionClick,
       onSearchInputChange,
       ouiaId,
       ouiaSafe,
-      isFlyoutMenu,
+      containsFlyout,
       hasSearchInput,
+      activeItemId = null,
       innerRef,
       ...props
     } = this.props;
 
     return (
-      <MenuContext.Provider value={{ onSelect, onActionClick }}>
+      <MenuContext.Provider value={{ onSelect, onActionClick, activeItemId, selected }}>
         <div
-          className={css(styles.menu, isFlyoutMenu && styles.modifiers.flyout, className)}
-          aria-label={ariaLabel || isFlyoutMenu ? 'Local' : 'Global'}
+          className={css(styles.menu, containsFlyout && styles.modifiers.flyout, className)}
+          aria-label={ariaLabel || containsFlyout ? 'Local' : 'Global'}
           ref={innerRef}
           {...getOUIAProps(Menu.displayName, ouiaId !== undefined ? ouiaId : this.state.ouiaStateId, ouiaSafe)}
           {...props}

--- a/packages/react-core/src/components/Menu/MenuContext.ts
+++ b/packages/react-core/src/components/Menu/MenuContext.ts
@@ -2,10 +2,14 @@ import * as React from 'react';
 
 export const MenuContext = React.createContext<{
   onSelect?: (event?: any, itemId?: any) => void;
-  onActionClick?: (event?: any, itemId?: any) => void;
+  onActionClick?: (event?: any, itemId?: any, actionId?: any) => void;
+  activeItemId?: any;
+  selected?: any | any[];
 }>({
   onActionClick: () => null,
-  onSelect: () => null
+  onSelect: () => null,
+  activeItemId: null,
+  selected: null
 });
 
 export const MenuItemContext = React.createContext<{

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -5,8 +5,9 @@ import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-
 import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
 import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
 import { MenuContext, MenuItemContext } from './MenuContext';
+import { MenuItemAction } from './MenuItemAction';
 
-export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'action' | 'onClick'> {
+export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'onClick'> {
   /** Content rendered inside the menu list item. */
   children?: React.ReactNode;
   /** Additional classes added to the menu list item */
@@ -17,6 +18,8 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'act
   to?: string;
   /** Flag indicating whether the item is active */
   isActive?: boolean;
+  /** Flag indicating if the item is favorited */
+  isFavorited?: boolean;
   /** Callback for item click */
   onClick?: (event?: any) => void;
   /** Component used to render the menu item */
@@ -25,16 +28,14 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'act
   isDisabled?: boolean;
   /** Render item with icon */
   icon?: React.ReactNode;
-  /** Render item with action */
-  action?: React.ReactNode;
+  /** Render item with one or more actions */
+  actions?: React.ReactNode;
   /** Description of the menu item */
   description?: React.ReactNode;
   /** Render external link icon */
   isExternalLink?: boolean;
-  /** Internal flag indicating if the option is selected */
+  /** Flag indicating if the option is selected */
   isSelected?: boolean;
-  /** Render expandable icon */
-  isExpandable?: boolean;
   /** Flyout menu */
   flyoutMenu?: React.ReactNode;
   /** Callback function when mouse leaves trigger */
@@ -48,19 +49,19 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'act
 const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
   children,
   className,
-  itemId,
+  itemId = null,
   to,
-  isActive = false,
+  isActive = null,
+  isFavorited = null,
   flyoutMenu,
   description = null as string,
   onClick = () => {},
   component,
   isDisabled = false,
   isExternalLink = false,
-  isExpandable = false,
-  isSelected = false,
+  isSelected = null,
   icon,
-  action,
+  actions,
   onShowFlyout,
   innerRef,
   ...props
@@ -80,7 +81,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
     onClick && onClick(event);
   };
 
-  const renderItem = (onSelect: any): React.ReactNode => {
+  const renderItem = (onSelect: any, activeItemId: any, selected: any | any[]): React.ReactNode => {
     const additionalProps =
       Component === 'a'
         ? {
@@ -89,12 +90,32 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
             tabIndex: isDisabled ? -1 : null
           }
         : {};
+    const getAriaCurrent = () => {
+      if (isActive !== null) {
+        if (isActive) {
+          return 'page';
+        } else {
+          return null;
+        }
+      } else if (itemId !== null && activeItemId !== null) {
+        return itemId === activeItemId;
+      }
+      return null;
+    };
+    const getIsSelected = () => {
+      if (isSelected !== null) {
+        return isSelected;
+      } else if (selected !== null && itemId !== null) {
+        return (Array.isArray(selected) && selected.includes(itemId)) || itemId === selected;
+      }
+      return false;
+    };
     return (
       <>
         <Component
           onClick={(event: any) => onItemSelect(event, onSelect)}
-          className={css(styles.menuItem, isSelected && styles.modifiers.selected, className)}
-          aria-current={isActive ? 'page' : null}
+          className={css(styles.menuItem, getIsSelected() && styles.modifiers.selected, className)}
+          aria-current={getAriaCurrent()}
           {...(isDisabled && { disabled: true })}
           {...additionalProps}
         >
@@ -106,12 +127,12 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
                 <ExternalLinkAltIcon aria-hidden />
               </span>
             )}
-            {isExpandable && (
+            {flyoutMenu && (
               <span className={css(styles.menuItemToggleIcon)}>
                 <AngleRightIcon aria-hidden />
               </span>
             )}
-            {isSelected && (
+            {getIsSelected() && (
               <span className={css(styles.menuItemSelectIcon)}>
                 <CheckIcon aria-hidden />
               </span>
@@ -137,10 +158,21 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
       {...props}
     >
       <MenuContext.Consumer>
-        {({ onSelect }) => (
+        {({ onSelect, onActionClick, activeItemId, selected }) => (
           <>
-            {renderItem(onSelect)}
-            <MenuItemContext.Provider value={{ itemId, isDisabled }}>{action}</MenuItemContext.Provider>
+            {renderItem(onSelect, activeItemId, selected)}
+            <MenuItemContext.Provider value={{ itemId, isDisabled }}>
+              {actions}
+              {isFavorited !== null && (
+                <MenuItemAction
+                  icon="favorites"
+                  isFavorited={isFavorited}
+                  aria-label={isFavorited ? 'starred' : 'not starred'}
+                  onClick={event => onActionClick(event, itemId)}
+                  actionId="fav"
+                />
+              )}
+            </MenuItemContext.Provider>
           </>
         )}
       </MenuContext.Consumer>

--- a/packages/react-core/src/components/Menu/MenuItemAction.tsx
+++ b/packages/react-core/src/components/Menu/MenuItemAction.tsx
@@ -9,14 +9,16 @@ export interface MenuItemActionProps extends Omit<React.HTMLProps<HTMLButtonElem
   className?: string;
   /** The action icon to use */
   icon?: 'favorites' | React.ReactNode;
-  /** Callback on action click, can also be specified on the Menu instead */
-  onActionClick?: (event?: any) => void;
+  /** Callback on action click, can also specify onActionClick on the Menu instead */
+  onClick?: (event?: any) => void;
   /** Accessibility label */
   'aria-label'?: string;
   /** Flag indicating if the item is favorited */
   isFavorited?: boolean;
   /** Disables action, can also be specified on the MenuItem instead */
   isDisabled?: boolean;
+  /** Identifies the action item in the onActionClick on the Menu */
+  actionId?: any;
   /** Forwarded ref */
   innerRef?: React.Ref<any>;
 }
@@ -24,22 +26,23 @@ export interface MenuItemActionProps extends Omit<React.HTMLProps<HTMLButtonElem
 const MenuItemActionBase: React.FunctionComponent<MenuItemActionProps> = ({
   className = '',
   icon,
-  onActionClick,
+  onClick,
   'aria-label': ariaLabel,
   isFavorited = null,
   isDisabled,
+  actionId,
   innerRef,
   ...props
 }: MenuItemActionProps) => (
   <MenuContext.Consumer>
-    {({ onActionClick: onActionClickContext }) => (
+    {({ onActionClick }) => (
       <MenuItemContext.Consumer>
         {({ itemId, isDisabled: isDisabledContext }) => {
           const onClickButton = (event: any) => {
             // event specified on the MenuItemAction
-            onActionClick && onActionClick(event);
+            onClick && onClick(event);
             // event specified on the Menu
-            onActionClickContext && onActionClickContext(event, itemId);
+            onActionClick && onActionClick(event, itemId, actionId);
           };
           return (
             <button

--- a/packages/react-core/src/components/Menu/examples/Menu.md
+++ b/packages/react-core/src/components/Menu/examples/Menu.md
@@ -30,6 +30,7 @@ class MenuBasicList extends React.Component {
       activeItem: 0
     };
     this.onSelect = (event, itemId) => {
+      console.log(`clicked ${itemId}`);
       this.setState({
         activeItem: itemId
       });
@@ -39,15 +40,13 @@ class MenuBasicList extends React.Component {
   render() {
     const { activeItem } = this.state;
     return (
-      <Menu>
+      <Menu activeItemId={activeItem} onSelect={this.onSelect}>
         <MenuList>
-          <MenuItem itemId={0} isActive={activeItem === 0} onClick={event => console.log('clicked')}>
-            Action
-          </MenuItem>
+          <MenuItem itemId={0}>Action</MenuItem>
           <MenuItem
             itemId={1}
             to="#default-link2"
-            isActive={activeItem === 1}
+            // just for demo so that navigation is not triggered
             onClick={event => event.preventDefault()}
           >
             Link
@@ -88,15 +87,15 @@ class MenuIconsList extends React.Component {
   render() {
     const { activeItem } = this.state;
     return (
-      <Menu onSelect={this.onSelect}>
+      <Menu onSelect={this.onSelect} activeItemId={activeItem}>
         <MenuList>
-          <MenuItem icon={<CodeBranchIcon aria-hidden />} itemId={0} isActive={activeItem === 0}>
+          <MenuItem icon={<CodeBranchIcon aria-hidden />} itemId={0}>
             From Git
           </MenuItem>
-          <MenuItem icon={<LayerGroupIcon aria-hidden />} itemId={1} isActive={activeItem === 1}>
+          <MenuItem icon={<LayerGroupIcon aria-hidden />} itemId={1}>
             Container Image
           </MenuItem>
-          <MenuItem icon={<CubeIcon aria-hidden />} itemId={2} isActive={activeItem === 2}>
+          <MenuItem icon={<CubeIcon aria-hidden />} itemId={2}>
             Docker File
           </MenuItem>
         </MenuList>
@@ -116,66 +115,38 @@ class MenuWithFlyout extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      activeItem: 0,
-      activeItemFlyout: 0
+      activeItem: 0
     };
     this.onSelect = (event, itemId) => {
       this.setState({
         activeItem: itemId
       });
     };
-    this.onSelectFlyout = (event, itemId) => {
-      this.setState({
-        activeItemFlyout: itemId
-      });
-    };
   }
 
   render() {
-    const { activeItem, activeItemFlyout } = this.state;
+    const { activeItem } = this.state;
     const flyoutMenu = (
-      <Menu onSelect={this.onSelectFlyout}>
+      <Menu onSelect={this.onSelect} activeItemId={activeItem}>
         <MenuList>
-          <MenuItem itemId={10} isActive={activeItemFlyout === 10}>
-            Application Grouping
-          </MenuItem>
-          <MenuItem itemId={11} isActive={activeItemFlyout === 11}>
-            Count
-          </MenuItem>
-          <MenuItem itemId={12} isActive={activeItemFlyout === 12}>
-            Labels
-          </MenuItem>
-          <MenuItem itemId={13} isActive={activeItemFlyout === 13}>
-            Annotations
-          </MenuItem>
+          <MenuItem itemId={10}>Application Grouping</MenuItem>
+          <MenuItem itemId={11}>Count</MenuItem>
+          <MenuItem itemId={12}>Labels</MenuItem>
+          <MenuItem itemId={13}>Annotations</MenuItem>
         </MenuList>
       </Menu>
     );
 
     return (
-      <Menu onSelect={this.onSelect} isFlyoutMenu>
+      <Menu containsFlyout onSelect={this.onSelect} activeItemId={activeItem}>
         <MenuList>
-          <MenuItem itemId={0} isActive={activeItem === 0}>
-            Start rollout
-          </MenuItem>
-          <MenuItem itemId={1} isActive={activeItem === 1}>
-            Pause rollouts
-          </MenuItem>
-          <MenuItem itemId={2} isActive={activeItem === 2}>
-            Add storage
-          </MenuItem>
-          <MenuItem
-            description="Description"
-            itemId={3}
-            isActive={activeItem === 3}
-            isExpandable
-            flyoutMenu={flyoutMenu}
-          >
+          <MenuItem itemId={0}>Start rollout</MenuItem>
+          <MenuItem itemId={1}>Pause rollouts</MenuItem>
+          <MenuItem itemId={2}>Add storage</MenuItem>
+          <MenuItem description="Description" itemId={3} flyoutMenu={flyoutMenu}>
             Edit
           </MenuItem>
-          <MenuItem itemId={4} isActive={activeItem === 4}>
-            Delete deployment config
-          </MenuItem>
+          <MenuItem itemId={4}>Delete deployment config</MenuItem>
         </MenuList>
       </Menu>
     );
@@ -217,7 +188,7 @@ class MenuWithFiltering extends React.Component {
     const menuListItems = menuListItemsText
       .filter(item => !input || item.toLowerCase().includes(input.toLowerCase()))
       .map((currentValue, index) => (
-        <MenuItem key={currentValue} itemId={index} isActive={activeItem === index}>
+        <MenuItem key={currentValue} itemId={index}>
           {currentValue}
         </MenuItem>
       ));
@@ -230,7 +201,7 @@ class MenuWithFiltering extends React.Component {
     }
 
     return (
-      <Menu hasSearchInput onSearchInputChange={this.onChange} onSelect={this.onSelect}>
+      <Menu hasSearchInput onSearchInputChange={this.onChange} onSelect={this.onSelect} activeItemId={activeItem}>
         <MenuList>{menuListItems}</MenuList>
       </Menu>
     );
@@ -260,15 +231,15 @@ class MenuWithLinks extends React.Component {
   render() {
     const { activeItem } = this.state;
     return (
-      <Menu onSelect={this.onSelect}>
+      <Menu onSelect={this.onSelect} activeItemId={activeItem}>
         <MenuList>
-          <MenuItem isExternalLink to="#default-link1" itemId={0} isActive={activeItem === 0}>
+          <MenuItem isExternalLink to="#default-link1" itemId={0}>
             Link 1
           </MenuItem>
-          <MenuItem isExternalLink to="#default-link2" itemId={1} isActive={activeItem === 1}>
+          <MenuItem isExternalLink to="#default-link2" itemId={1}>
             Link 2
           </MenuItem>
-          <MenuItem to="#default-link3" itemId={2} isActive={activeItem === 2}>
+          <MenuItem to="#default-link3" itemId={2}>
             Link 3
           </MenuItem>
         </MenuList>
@@ -300,18 +271,12 @@ class MenuWithSeparators extends React.Component {
   render() {
     const { activeItem } = this.state;
     return (
-      <Menu onSelect={this.onSelect}>
+      <Menu onSelect={this.onSelect} activeItemId={activeItem}>
         <MenuList>
-          <MenuItem itemId={0} isActive={activeItem === 0}>
-            Action 1
-          </MenuItem>
-          <MenuItem itemId={1} isActive={activeItem === 1}>
-            Action 2
-          </MenuItem>
+          <MenuItem itemId={0}>Action 1</MenuItem>
+          <MenuItem itemId={1}>Action 2</MenuItem>
           <Divider component="li" />
-          <MenuItem itemId={2} isActive={activeItem === 2}>
-            Action 3
-          </MenuItem>
+          <MenuItem itemId={2}>Action 3</MenuItem>
         </MenuList>
       </Menu>
     );
@@ -341,10 +306,10 @@ class MenuWithTitledGroups extends React.Component {
   render() {
     const { activeItem } = this.state;
     return (
-      <Menu onSelect={this.onSelect}>
+      <Menu onSelect={this.onSelect} activeItemId={activeItem}>
         <MenuGroup>
           <MenuList>
-            <MenuItem to="#" itemId={0} isActive={activeItem === 0}>
+            <MenuItem to="#" itemId={0}>
               Link not in group
             </MenuItem>
           </MenuList>
@@ -352,21 +317,19 @@ class MenuWithTitledGroups extends React.Component {
         <Divider />
         <MenuGroup label="Group 1">
           <MenuList>
-            <MenuItem to="#" itemId={1} isActive={activeItem === 1}>
+            <MenuItem to="#" itemId={1}>
               Link 1
             </MenuItem>
-            <MenuItem itemId={2} isActive={activeItem === 2}>
-              Link 2
-            </MenuItem>
+            <MenuItem itemId={2}>Link 2</MenuItem>
           </MenuList>
         </MenuGroup>
         <Divider />
         <MenuGroup label="Group 2">
           <MenuList>
-            <MenuItem to="#" itemId={3} isActive={activeItem === 3}>
+            <MenuItem to="#" itemId={3}>
               Link 1
             </MenuItem>
-            <MenuItem to="#" itemId={4} isActive={activeItem === 4}>
+            <MenuItem to="#" itemId={4}>
               Link 2
             </MenuItem>
           </MenuList>
@@ -402,30 +365,18 @@ class MenuWithDescription extends React.Component {
   render() {
     const { activeItem } = this.state;
     return (
-      <Menu onSelect={this.onSelect}>
+      <Menu onSelect={this.onSelect} activeItemId={activeItem}>
         <MenuList>
-          <MenuItem
-            icon={<CodeBranchIcon aria-hidden />}
-            description="Description"
-            itemId={0}
-            isActive={activeItem === 0}
-          >
+          <MenuItem icon={<CodeBranchIcon aria-hidden />} description="Description" itemId={0}>
             Action 1
           </MenuItem>
-          <MenuItem
-            isDisabled
-            icon={<CodeBranchIcon aria-hidden />}
-            description="Description"
-            itemId={1}
-            isActive={activeItem === 1}
-          >
+          <MenuItem isDisabled icon={<CodeBranchIcon aria-hidden />} description="Description" itemId={1}>
             Action 2 disabled
           </MenuItem>
           <MenuItem
             icon={<CodeBranchIcon aria-hidden />}
             description="Nunc non ornare ex, et pretium dui. Duis nec augue at urna elementum blandit tincidunt eget metus. Aenean sed metus id urna dignissim interdum. Aenean vel nisl vitae arcu vehicula pulvinar eget nec turpis. Cras sit amet est est."
             itemId={2}
-            isActive={activeItem === 2}
           >
             Action 3
           </MenuItem>
@@ -475,48 +426,49 @@ class MenuWithActions extends React.Component {
     const { activeItem, selectedItems } = this.state;
 
     return (
-      <Menu onSelect={this.onSelect} onActionClick={(event, itemId) => console.log(`clicked on ${itemId}`)}>
+      <Menu
+        onSelect={this.onSelect}
+        onActionClick={(event, itemId, actionId) => console.log(`clicked on ${itemId} - ${actionId}`)}
+        activeItemId={activeItem}
+      >
         <MenuGroup label="Actions">
           <MenuList>
             <MenuItem
-              isSelected={selectedItems.indexOf(0) != -1}
-              action={
+              isSelected={selectedItems.indexOf(0) !== -1}
+              actions={
                 <MenuItemAction
                   icon={<CodeBranchIcon aria-hidden />}
-                  onActionClick={() => console.log('clicked on code icon')}
+                  actionId="code"
+                  onClick={() => console.log('clicked on code icon')}
                   aria-label="Code"
                 />
               }
               description="This is a description"
               itemId={0}
-              isActive={activeItem === 0}
             >
               Item 1
             </MenuItem>
             <MenuItem
               isDisabled
-              isSelected={selectedItems.indexOf(1) != -1}
-              action={<MenuItemAction icon={<BellIcon aria-hidden />} aria-label="Alert" />}
+              isSelected={selectedItems.indexOf(1) !== -1}
+              actions={<MenuItemAction icon={<BellIcon aria-hidden />} actionId="alert" aria-label="Alert" />}
               description="This is a description"
               itemId={1}
-              isActive={activeItem === 1}
             >
               Item 2
             </MenuItem>
             <MenuItem
-              isSelected={selectedItems.indexOf(2) != -1}
-              action={<MenuItemAction icon={<ClipboardIcon aria-hidden />} aria-label="Copy" />}
+              isSelected={selectedItems.indexOf(2) !== -1}
+              actions={<MenuItemAction icon={<ClipboardIcon aria-hidden />} actionId="copy" aria-label="Copy" />}
               itemId={2}
-              isActive={activeItem === 2}
             >
               Item 3
             </MenuItem>
             <MenuItem
-              isSelected={selectedItems.indexOf(3) != -1}
-              action={<MenuItemAction icon={<BarsIcon aria-hidden />} aria-label="Expand" />}
+              isSelected={selectedItems.indexOf(3) !== -1}
+              actions={<MenuItemAction icon={<BarsIcon aria-hidden />} actionId="expand" aria-label="Expand" />}
               description="This is a description"
               itemId={3}
-              isActive={activeItem === 3}
             >
               Item 4
             </MenuItem>
@@ -533,6 +485,9 @@ class MenuWithActions extends React.Component {
 ```js
 import React from 'react';
 import { Menu, MenuItem, MenuItemAction, MenuGroup, MenuList, Divider } from '@patternfly/react-core';
+import BarsIcon from '@patternfly/react-icons/dist/js/icons/bars-icon';
+import ClipboardIcon from '@patternfly/react-icons/dist/js/icons/clipboard-icon';
+import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 
 class MenuWithFavorites extends React.Component {
   constructor(props) {
@@ -547,16 +502,19 @@ class MenuWithFavorites extends React.Component {
         activeItem: itemId
       });
     };
-    this.onFavorite = (event, itemId) => {
-      const isFavorite = this.state.favorites.includes(itemId);
-      if (isFavorite) {
-        this.setState({
-          favorites: this.state.favorites.filter(fav => fav !== itemId)
-        });
-      } else {
-        this.setState({
-          favorites: [...this.state.favorites, itemId]
-        });
+    this.onFavorite = (event, itemId, actionId) => {
+      console.log(`clicked ${itemId} - ${actionId}`);
+      if (actionId === 'fav') {
+        const isFavorite = this.state.favorites.includes(itemId);
+        if (isFavorite) {
+          this.setState({
+            favorites: this.state.favorites.filter(fav => fav !== itemId)
+          });
+        } else {
+          this.setState({
+            favorites: [...this.state.favorites, itemId]
+          });
+        }
       }
     };
   }
@@ -568,25 +526,28 @@ class MenuWithFavorites extends React.Component {
       {
         text: 'Item 1',
         description: 'Description 1',
-        isActive: activeItem === 0,
-        itemId: 'item-1'
+        itemId: 'item-1',
+        action: <BarsIcon aria-hidden />,
+        actionId: 'bars'
       },
       {
         text: 'Item 2',
         description: 'Description 2',
-        isActive: activeItem === 1,
-        itemId: 'item-2'
+        itemId: 'item-2',
+        action: <ClipboardIcon aria-hidden />,
+        actionId: 'clipboard'
       },
       {
         text: 'Item 3',
         description: 'Description 3',
-        isActive: activeItem === 2,
-        itemId: 'item-3'
+        itemId: 'item-3',
+        action: <BellIcon aria-hidden />,
+        actionId: 'bell'
       }
     ];
 
     return (
-      <Menu onSelect={this.onSelect} onActionClick={this.onFavorite}>
+      <Menu onSelect={this.onSelect} onActionClick={this.onFavorite} activeItemId={activeItem}>
         {favorites.length > 0 && (
           <React.Fragment>
             <MenuGroup label="Favorites">
@@ -595,13 +556,20 @@ class MenuWithFavorites extends React.Component {
                   // map the items into the favorites group that have been favorited
                   .filter(item => favorites.includes(item.itemId))
                   .map(item => {
-                    const { text, itemId, ...rest } = item;
+                    const { text, description, itemId, action, actionId } = item;
                     return (
                       <MenuItem
                         key={`fav-${itemId}`}
+                        isFavorited
+                        description={description}
                         itemId={itemId}
-                        action={<MenuItemAction icon="favorites" isFavorited aria-label="starred" />}
-                        {...rest}
+                        actions={
+                          <MenuItemAction
+                            actionId={actionId}
+                            icon={action}
+                            aria-label={actionId}
+                          />
+                        }
                       >
                         {text}
                       </MenuItem>
@@ -615,20 +583,21 @@ class MenuWithFavorites extends React.Component {
         <MenuGroup label="All actions">
           <MenuList>
             {items.map(item => {
-              const { text, itemId, ...rest } = item;
+              const { text, description, itemId, action, actionId } = item;
               const isFavorited = favorites.includes(item.itemId);
               return (
                 <MenuItem
                   key={itemId}
+                  isFavorited={isFavorited}
+                  description={description}
                   itemId={itemId}
-                  action={
+                  actions={
                     <MenuItemAction
-                      icon="favorites"
-                      isFavorited={isFavorited}
-                      aria-label={isFavorited ? 'starred' : 'not starred'}
+                      actionId={actionId}
+                      icon={action}
+                      aria-label={actionId}
                     />
                   }
-                  {...rest}
                 >
                   {text}
                 </MenuItem>
@@ -668,20 +637,11 @@ class MenuOptionSingleSelect extends React.Component {
   render() {
     const { activeItem, selectedItem } = this.state;
     return (
-      <Menu onSelect={this.onSelect}>
+      <Menu onSelect={this.onSelect} activeItemId={activeItem} selected={selectedItem}>
         <MenuList>
-          <MenuItem itemId={0} isActive={activeItem === 0} isSelected={selectedItem === 0}>
-            Option 1
-          </MenuItem>
-          <MenuItem itemId={1} isActive={activeItem === 1} isSelected={selectedItem === 1}>
-            Option 2
-          </MenuItem>
-          <MenuItem
-            icon={<TableIcon aria-hidden />}
-            itemId={2}
-            isActive={activeItem === 2}
-            isSelected={selectedItem === 2}
-          >
+          <MenuItem itemId={0}>Option 1</MenuItem>
+          <MenuItem itemId={1}>Option 2</MenuItem>
+          <MenuItem icon={<TableIcon aria-hidden />} itemId={2}>
             Option 3
           </MenuItem>
         </MenuList>
@@ -721,20 +681,11 @@ class MenuOptionMultiSelect extends React.Component {
   render() {
     const { activeItem, selectedItems } = this.state;
     return (
-      <Menu onSelect={this.onSelect}>
+      <Menu onSelect={this.onSelect} activeItemId={activeItem} selected={selectedItems}>
         <MenuList>
-          <MenuItem itemId={0} isActive={activeItem === 0} isSelected={selectedItems.indexOf(0) !== -1}>
-            Option 1
-          </MenuItem>
-          <MenuItem itemId={1} isActive={activeItem === 1} isSelected={selectedItems.indexOf(1) !== -1}>
-            Option 2
-          </MenuItem>
-          <MenuItem
-            icon={<TableIcon aria-hidden />}
-            itemId={2}
-            isActive={activeItem === 2}
-            isSelected={selectedItems.indexOf(2) != -1}
-          >
+          <MenuItem itemId={0}>Option 1</MenuItem>
+          <MenuItem itemId={1}>Option 2</MenuItem>
+          <MenuItem icon={<TableIcon aria-hidden />} itemId={2}>
             Option 3
           </MenuItem>
         </MenuList>


### PR DESCRIPTION
- instead of `isActive` and `isSelected` on the `MenuItem` level can now use `activeItemId` and `selected` on the Menu level
- renamed `isFlyoutMenu` => `containsFlyout` since that conveys a more accurate meaning
- renamed `action` => `actions`  in the `MenuItem` since you can add more than one action
- added `actionId` to `MenuItemAction` which will get passed back in the `onActionClick` callback on the `Menu`
- added `isFavorited` as a convenience prop to `MenuItem` although you could still instead pass it as a `MenuItemAction`